### PR TITLE
Record tracks while playing

### DIFF
--- a/index.css
+++ b/index.css
@@ -57,6 +57,13 @@ input[type="file"] {
     cursor: pointer; 
 }
 
+.error-message {
+    color: red;
+    font-size: 14px;
+    text-align: center;
+    margin-bottom: 20px;
+    display: none;
+}
 
 .slider {
     -webkit-appearance: none;  /* Override default CSS styles */

--- a/index.css
+++ b/index.css
@@ -8,10 +8,17 @@ body {
     color: white;
     text-align: center;
     font-size: 25px;
-    position: relative;
-    top: 20px
+    margin-top: 50px
 }
 
+.controls-container {
+    display: flex;
+    align-items: center; 
+    justify-content: center;
+    gap: 10px; 
+    margin-top: 40px;
+    margin-bottom: 20px;
+}
 
 .button-play {
     border: 0;
@@ -26,14 +33,7 @@ body {
 
     border-style: solid;
     border-width: 18px 0 18px 30px;
-
-    display: flex;
-    position: relative;
-    top: 17px;
-    right: 32px;
-    margin: 0 auto;
 }
-
 
 .button-stop {
     background-color: rgb(255, 255, 255);
@@ -42,12 +42,6 @@ body {
     width: 37px;
 
     cursor: pointer;
-    
-    display: flex;
-    position: relative;
-    top: -20px;
-    right: -18px;
-    margin: 0 auto; 
 }
 
 
@@ -55,20 +49,35 @@ input[type="file"] {
     display: none;
 }
 
-.fileUpload {
+.file-upload {
     background: white;
     color: #242121;
     width: 65px;
     padding: 11px 12px;
     cursor: pointer; 
-    
-    display: flex;
-    position: relative;
-    top: 70px;
-    right: 132px;
-    margin: 0 auto;
 }
 
+
+.slider {
+    -webkit-appearance: none;  /* Override default CSS styles */
+    appearance: none;
+    width: 100px; 
+    height: 15px;
+    background: #ffffff; 
+    outline: none; 
+    opacity: 1; 
+}
+
+.slider::-webkit-slider-thumb {
+    -webkit-appearance: none; /* Override default look */
+    appearance: none;
+    width: 15px; 
+    height: 15px; 
+    background: #242121; 
+    cursor: pointer; 
+    outline: solid white;
+    outline-width: 2px;
+  }
 
 
 .blueLine1 {
@@ -135,34 +144,6 @@ input[type="file"] {
     z-index: -1;
 }
 
-
-
-.slider {
-    -webkit-appearance: none;  /* Override default CSS styles */
-    appearance: none;
-    width: 100px; 
-    height: 15px;
-    background: #ffffff; 
-    outline: none; 
-    opacity: 1; 
-
-    display: flex;
-    position: relative;
-    top: 43px;
-    right: -123px;
-    margin: 0 auto;
-}
-
-.slider::-webkit-slider-thumb {
-    -webkit-appearance: none; /* Override default look */
-    appearance: none;
-    width: 15px; 
-    height: 15px; 
-    background: #242121; 
-    cursor: pointer; 
-    outline: solid white;
-    outline-width: 2px;
-  }
 
 .wave {
     background: rgb(255, 255, 255);

--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     <title>Midi to Chiptune</title>
     <link rel="stylesheet" href="index.css">
     <link href="https://fonts.googleapis.com/css?family=Press+Start+2P" rel="stylesheet">
-    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.13/Tone.js"></script> -->
-    <!-- displays 'dev' as version -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.13/Tone.js"></script>
+    <!-- Only necessary when using recorder.pause() to allow resuming -->
     <script src="https://rupel190.github.io/Tone.js/Tone.js"></script> 
     <script src="https://unpkg.com/@tonejs/midi@2.0.27/build/Midi.js"></script>
 </head>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,8 @@
     <link rel="stylesheet" href="index.css">
     <link href="https://fonts.googleapis.com/css?family=Press+Start+2P" rel="stylesheet">
     <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.13/Tone.js"></script> -->
-    <script src="https://rupel190.github.io/Tone.js/Tone.js"></script> //displays 'dev' as version
+    <!-- displays 'dev' as version -->
+    <script src="https://rupel190.github.io/Tone.js/Tone.js"></script> 
     <script src="https://unpkg.com/@tonejs/midi@2.0.27/build/Midi.js"></script>
 </head>
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@
     <title>Midi to Chiptune</title>
     <link rel="stylesheet" href="index.css">
     <link href="https://fonts.googleapis.com/css?family=Press+Start+2P" rel="stylesheet">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.13/Tone.js"></script>
+    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.13/Tone.js"></script> -->
+    <script src="https://rupel190.github.io/Tone.js/Tone.js"></script> //displays 'dev' as version
     <script src="https://unpkg.com/@tonejs/midi@2.0.27/build/Midi.js"></script>
 </head>
 
@@ -26,7 +27,7 @@
         <input type='file' id='file-selector' accept=".mid" oninput="loadFile()">
 
         <label for="save-recording" class="file-upload" onclick="save()">Save</label>
-
+        
         <div class="slideContainer">
             <input class="slider" type="range" min="-60" max="0" value="-15" id="volSlider" oninput="setVolume(this.value)" onchange="setVolume(this.value)">
         </div>
@@ -34,6 +35,7 @@
         <button class="button-play" onclick="playPause()"></button>
         <button class="button-stop" onclick="stop()"></button>
     </div>
+    <div id="error-message" class="error-message"></div>
     
     
     <div class="wave">

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 
 <body>
     <div class="header">Midi to Chiptune</div>    
-
+    
     <div class="blueLine1"></div>
     <div class="blueLine2"></div>
     <div class="yellowLine1"></div>
@@ -21,17 +21,20 @@
     <div class="redLine1"></div>
     <div class="redLine2"></div>
     
-    <label for="file-selector" class="fileUpload">Load</label>
-    <input type='file' id='file-selector' accept=".mid" oninput="loadFile()">
-    
-    <div class="slideContainer"></div>
-        <input class="slider" type="range" min="-60" max="0" value="-15" id="volSlider" oninput="setVolume(this.value)" onchange="setVolume(this.value)">
-    </div>
+    <div class="controls-container">
+        <label for="file-selector" class="file-upload">Load</label>
+        <input type='file' id='file-selector' accept=".mid" oninput="loadFile()">
 
-    <div class="container">
+        <label for="save-recording" class="file-upload" onclick="save()">Save</label>
+
+        <div class="slideContainer">
+            <input class="slider" type="range" min="-60" max="0" value="-15" id="volSlider" oninput="setVolume(this.value)" onchange="setVolume(this.value)">
+        </div>
+
         <button class="button-play" onclick="playPause()"></button>
         <button class="button-stop" onclick="stop()"></button>
     </div>
+    
     
     <div class="wave">
         <span></span><canvas id="wave0" width="250" height="100"></canvas>

--- a/index.js
+++ b/index.js
@@ -1,4 +1,13 @@
+
+let recorder;
+let download;
+const errorMessage = document.getElementById('error-message');
+
 function loadFile() {
+    console.log('Tone.js custom version:', Tone.version);
+    
+    // Init recorder
+    initRecorder(); 
     // Stop any playback and clear current song
     stop();
     Tone.Transport.cancel();
@@ -7,11 +16,10 @@ function loadFile() {
     Tone.getDestination().volume.value = document.getElementById('volSlider').value;
     
     // Get all the midi data
-    const midiData = getMidi();    
+    const midiData = getMidi();   
 
     // If a midi file has been  it for playback
     midiData.then((midiData) => {
-
         // Establish an intrument/analyers/notes for each track
         const instruments = getInstruments(midiData);
         getAnalysers(instruments);
@@ -28,6 +36,42 @@ function loadFile() {
             }, time);
         });
     })
+
+}
+
+function initRecorder() {
+    recorder = new Tone.Recorder();
+    console.log('Init recorder: ', recorder);
+    Tone.getDestination().connect(recorder);
+
+    Tone.Transport.on('start', () => {
+        console.log('Start event, current recorder state: ', recorder.state);
+        recorder.start();
+        console.log('After starting: ', recorder.state);
+    });
+
+    Tone.Transport.on('stop', () => {
+        console.log('Stop event, current recorder state: ', recorder.state);
+        
+        setTimeout(async () => {
+            // recording is returned as a blob
+            const recording = await recorder.stop();
+            // download by creating an anchor element and blob url
+            const url = URL.createObjectURL(recording);
+            const anchor = document.createElement("a");
+            anchor.download = "recording.webm";
+            anchor.href = url;
+            // anchor.click();
+            download = anchor;
+        }, 500); // tail end
+        console.log('After stopping: ', recorder.state);
+    });
+
+    Tone.Transport.on('pause', () => {
+        console.log('Pause event, current recorder state: ', recorder.state);
+        recorder.pause();
+        console.log('After pausing: ', recorder.state);
+    })
 }
 
 
@@ -36,19 +80,42 @@ function setVolume(sliderVal) {
     Tone.getDestination().volume.value = sliderVal;
 }
 
-
-// Start playback
 function playPause() {
     if (Tone.Transport.state === 'started') {
+        console.log('Pause tone');
         Tone.Transport.pause();
     }
-    else {
+    else if(Tone.Transport.state === 'paused' || Tone.Transport.state === 'stopped') {
+        console.log('Resume tone');
         Tone.Transport.start()
     }  
+
 }
   
-
-// Stop playback
 function stop() {
-    Tone.Transport.stop();
+    if (Tone.Transport.state !== 'stopped') {
+        console.log('Stop tone');
+        Tone.Transport.stop();
+    }
 }
+
+function save() {
+    let customRecorder = new Tone.Recorder();
+    customRecorder.start();
+    console.log('customrecorder: ', customRecorder.state);
+    customRecorder.pause();
+    console.log('customrecorder: ', customRecorder.state);
+    customRecorder.start();
+    console.log('customrecorder: ', customRecorder.state);
+
+
+    console.log('Download clicked!');
+    if (download) {
+        download.click();
+    } else {
+        errorMessage.textContent = 'No recording available. Load and play first.';
+        errorMessage.style.display = 'block'; // Show error message
+        setTimeout(() => { errorMessage.style.display = 'none'; }, 5000);
+    }
+}
+

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function loadFile() {
 
         // Load and schedule each part for tracks that have notes
         getParts(notes, instruments);
-        
+
         // Schedule drawing to take place as soon as playback starts
         Tone.Transport.schedule((time) => {
             Tone.Draw.schedule(() => { 
@@ -63,7 +63,7 @@ function initRecorder() {
             anchor.href = url;
             // anchor.click();
             download = anchor;
-        }, 500); // tail end
+        }, 500); // tail end necessar?
         console.log('After stopping: ', recorder.state);
     });
 
@@ -71,7 +71,12 @@ function initRecorder() {
         console.log('Pause event, current recorder state: ', recorder.state);
         recorder.pause();
         console.log('After pausing: ', recorder.state);
-    })
+    });
+
+    Tone.Transport.on('ended', () => {
+        console.log('Song FINISHED!!!!!!!!!!!!!!!!!!!!!!!');
+        // stop, ...
+    });
 }
 
 
@@ -100,15 +105,6 @@ function stop() {
 }
 
 function save() {
-    let customRecorder = new Tone.Recorder();
-    customRecorder.start();
-    console.log('customrecorder: ', customRecorder.state);
-    customRecorder.pause();
-    console.log('customrecorder: ', customRecorder.state);
-    customRecorder.start();
-    console.log('customrecorder: ', customRecorder.state);
-
-
     console.log('Download clicked!');
     if (download) {
         download.click();
@@ -117,5 +113,8 @@ function save() {
         errorMessage.style.display = 'block'; // Show error message
         setTimeout(() => { errorMessage.style.display = 'none'; }, 5000);
     }
+
+    console.log('check it: ', Tone.Transport.loopEnd);
+    console.log('check to: ', Tone.Transport.position);
 }
 

--- a/index.js
+++ b/index.js
@@ -96,6 +96,10 @@ function playPause() {
     }  
 
 }
+
+function callbackTrackEnd() {
+    console.log('HEY, THE TRACK IS OVEr AND tHATs GOOD!');
+}
   
 function stop() {
     if (Tone.Transport.state !== 'stopped') {

--- a/midi.js
+++ b/midi.js
@@ -91,14 +91,29 @@ function getParts(notes, instruments) {
 
     for (let track = 0; track < Object.keys(notes).length; track++) {
         if (notes[track].length) {
+            // Introduce END marker https://github.com/Tonejs/Tone.js/issues/802
+            const lastNote = notes[track][notes[track].length - 1];
+            const endMarker = { time: lastNote.time + lastNote.duration, duration: 0, note: 'END' };
+            notes[track].push(endMarker);
+            console.log('Notes: ', notes[track]);
+
             parts[track] = new Tone.Part(((time, value) => {
-                // Check if the track is drums/noise and leave out note names if so
-                if (instruments[track].name === 'NoiseSynth') {
-                    instruments[track].triggerAttackRelease(value.duration, time, value.velocity);
+
+                console.log('Note: ', value.note)
+                
+                if (value.note === 'END') {
+                    console.log('Sequence ended for track', track);
+                    callbackTrackEnd();
                 } else {
-                    instruments[track].triggerAttackRelease(value.note, value.duration, time, value.velocity);
+                    // Check if the track is drums/noise and leave out note names if so
+                    if (instruments[track].name === 'NoiseSynth') {
+                        instruments[track].triggerAttackRelease(value.duration, time, value.velocity);
+                    } else {
+                        instruments[track].triggerAttackRelease(value.note, value.duration, time, value.velocity);
+                    }
                 }
             }), notes[track]).start(0);
+        
         }
     } 
 }

--- a/midi.js
+++ b/midi.js
@@ -92,18 +92,16 @@ function getParts(notes, instruments) {
     for (let track = 0; track < Object.keys(notes).length; track++) {
         if (notes[track].length) {
             // Introduce END marker https://github.com/Tonejs/Tone.js/issues/802
-            const lastNote = notes[track][notes[track].length - 1];
+            const lastNote = notes[track].at(-1);
             const endMarker = { time: lastNote.time + lastNote.duration, duration: 0, note: 'END' };
             notes[track].push(endMarker);
             console.log('Notes: ', notes[track]);
 
             parts[track] = new Tone.Part(((time, value) => {
-
-                console.log('Note: ', value.note)
-                
                 if (value.note === 'END') {
                     console.log('Sequence ended for track', track);
-                    callbackTrackEnd();
+                    const event = new CustomEvent('seqEnd', { detail: { message: 'Sequence has ended.' } });
+                    document.dispatchEvent(event);
                 } else {
                     // Check if the track is drums/noise and leave out note names if so
                     if (instruments[track].name === 'NoiseSynth') {

--- a/visualize.js
+++ b/visualize.js
@@ -34,23 +34,24 @@ function allContext(instruments) {
 // Create soundwave of each instrument
 function createWave(context, values, color) {
     const canvasWidth = 250, canvasHeight = 100;
-
-    context.clearRect(0, 0, canvasWidth, canvasHeight);
-    context.beginPath();
-  
-    context.lineJoin = "round";
-    context.lineWidth = 2;
+    if(context != null) {
+      context.clearRect(0, 0, canvasWidth, canvasHeight);
+      context.beginPath();
     
-  
-    context.moveTo(0, (values[0] / 255) * canvasHeight);
-    for (let i = 1, len = values.length; i < len; i++){
-      let val = values[i];
-      let x = canvasWidth * (i / len);
-      let y = val * canvasHeight;
-      context.lineTo(x, y);
+      context.lineJoin = "round";
+      context.lineWidth = 2;
+      
+    
+      context.moveTo(0, (values[0] / 255) * canvasHeight);
+      for (let i = 1, len = values.length; i < len; i++){
+        let val = values[i];
+        let x = canvasWidth * (i / len);
+        let y = val * canvasHeight;
+        context.lineTo(x, y);
+      }
+      context.stroke();
+      context.strokeStyle = colors[color % 4];
     }
-    context.stroke();
-    context.strokeStyle = colors[color % 4];
   }
 
 


### PR DESCRIPTION
Adds recording feature

Volume is unaffected and carries over into the recording. Pauses also carry over, the recorder just keeps running. (Theoretically it would be possible, but I had to use my own fork of Tone.js for resuming after a recorder.pause(). Also introduces complex timing issues.)
The core logic is extended based on events and promises, HTML/CSS is also simplified.

Example usage:

    Load track
    Play
    Press save or stop: Save stops and downloads the recording. Stop stops the recording, leaving the option to save manually. Both result in the stopped state where the next "Play" reinitializes the recorder.
